### PR TITLE
v2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v2.3.3
+
+* Fix `check_values()` for `num_points` less than or greater than 3.
+
+# v2.3.2
+
+* Remove w3lib dependency
+
 # v2.3.0
 
 * Forbid extra attributes to all models

--- a/src/czml3/__init__.py
+++ b/src/czml3/__init__.py
@@ -1,5 +1,5 @@
 from .core import CZML_VERSION, Document, Packet
 
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 
 __all__ = ["Document", "Packet", "CZML_VERSION"]

--- a/src/czml3/types.py
+++ b/src/czml3/types.py
@@ -83,7 +83,7 @@ def check_values(num_points: int, values: list[Any]):
             f"Input values must have either {num_points} or N * {num_points + 1} values, where N is the number of time-tagged samples."
         )
     if len(values) % (num_points + 1) == 0 and np.any(
-        np.diff(values[:: (num_points + 1)]) <= 0
+        np.diff(values[:: num_points + 1]) <= 0
     ):
         raise TypeError("Time values must be increasing.")
 


### PR DESCRIPTION
- Bump to v2.3.3
- Update changelog
- Fix `check_values()` for `num_points` less than or greater than 3