### PR TITLE
Update Position validator to ensure reference can be specified alone

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -422,7 +422,7 @@ class ViewFrom(BaseCZMLObject, Interpolatable, Deletable):
 
     See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/ViewFrom>`__ for it's definition."""
 
-    cartesian: None | Cartesian3Value | list[float] | TimeIntervalCollection = Field()
+    cartesian: None | Cartesian3Value | list[float] | TimeIntervalCollection = Field(default=None)
     """The offset specified as a three-dimensional Cartesian value [X, Y, Z].  See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Cartesian3Value>`__ for it's definition."""
     reference: None | ReferenceValue | str | TimeIntervalCollection = Field(
         default=None
@@ -442,6 +442,14 @@ class ViewFrom(BaseCZMLObject, Interpolatable, Deletable):
         if isinstance(r, str):
             return ReferenceValue(value=r)
         return r
+    
+    @model_validator(mode="after")
+    def checks(self):
+        if self.delete:
+            return self
+        if self.cartesian is None and self.reference is None:
+            raise ValueError("ViewFrom must have either 'cartesian' or 'reference' specified")
+        return self
 
 
 class Billboard(BaseCZMLObject):

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -422,7 +422,9 @@ class ViewFrom(BaseCZMLObject, Interpolatable, Deletable):
 
     See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/ViewFrom>`__ for it's definition."""
 
-    cartesian: None | Cartesian3Value | list[float] | TimeIntervalCollection = Field(default=None)
+    cartesian: None | Cartesian3Value | list[float] | TimeIntervalCollection = Field(
+        default=None
+    )
     """The offset specified as a three-dimensional Cartesian value [X, Y, Z].  See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Cartesian3Value>`__ for it's definition."""
     reference: None | ReferenceValue | str | TimeIntervalCollection = Field(
         default=None
@@ -448,7 +450,9 @@ class ViewFrom(BaseCZMLObject, Interpolatable, Deletable):
         if self.delete:
             return self
         if self.cartesian is None and self.reference is None:
-            raise ValueError("ViewFrom must have either 'cartesian' or 'reference' specified")
+            raise ValueError(
+                "ViewFrom must have either 'cartesian' or 'reference' specified"
+            )
         return self
 
 

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -442,7 +442,7 @@ class ViewFrom(BaseCZMLObject, Interpolatable, Deletable):
         if isinstance(r, str):
             return ReferenceValue(value=r)
         return r
-    
+
     @model_validator(mode="after")
     def checks(self):
         if self.delete:

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -366,6 +366,7 @@ class Position(BaseCZMLObject, Interpolatable, Deletable):
                     self.cartographicDegrees,
                     self.cartographicRadians,
                     self.cartesianVelocity,
+                    self.reference,
                 )
             )
             != 1

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -756,9 +756,7 @@ def test_position_reference():
 }"""
     pos = Position(reference="this#satellite")
     assert str(pos) == expected_result
-    pos = Position(
-        reference=ReferenceValue(value="this#satellite")
-    )
+    pos = Position(reference=ReferenceValue(value="this#satellite"))
     assert str(pos) == expected_result
 
 
@@ -768,9 +766,7 @@ def test_viewfrom_reference():
 }"""
     v = ViewFrom(reference="this#satellite")
     assert str(v) == expected_result
-    v = ViewFrom(
-        reference=ReferenceValue(value="this#satellite")
-    )
+    v = ViewFrom(reference=ReferenceValue(value="this#satellite"))
     assert str(v) == expected_result
 
 
@@ -798,7 +794,7 @@ def test_viewfrom_has_delete():
 
 def test_viewfrom_no_values_raises_error():
     with pytest.raises(ValidationError) as _:
-        ViewFrom()  # type: ignore
+        ViewFrom()
 
 
 def test_single_interval_value():
@@ -1500,24 +1496,26 @@ def test_position_bad_cartesianVelocity():
     with pytest.raises(ValueError):
         Position(cartesianVelocity=[])
 
+
 def test_position_bad_multipleTypes():
     with pytest.raises(TypeError):
-        Position(cartesian=[0],reference=ReferenceValue(value="1#this"))
+        Position(cartesian=[0], reference=ReferenceValue(value="1#this"))
     with pytest.raises(TypeError):
-        Position(cartographicRadians=[0],reference=ReferenceValue(value="1#this"))
+        Position(cartographicRadians=[0], reference=ReferenceValue(value="1#this"))
     with pytest.raises(TypeError):
-        Position(cartographicDegrees=[0],reference=ReferenceValue(value="1#this"))
+        Position(cartographicDegrees=[0], reference=ReferenceValue(value="1#this"))
     with pytest.raises(TypeError):
-        Position(cartesianVelocity=[0],reference=ReferenceValue(value="1#this"))
+        Position(cartesianVelocity=[0], reference=ReferenceValue(value="1#this"))
 
     with pytest.raises(TypeError):
-        Position(cartesian=[0],reference="1#this")
+        Position(cartesian=[0], reference="1#this")
     with pytest.raises(TypeError):
-        Position(cartographicRadians=[0],reference="1#this")
+        Position(cartographicRadians=[0], reference="1#this")
     with pytest.raises(TypeError):
-        Position(cartographicDegrees=[0],reference="1#this")
+        Position(cartographicDegrees=[0], reference="1#this")
     with pytest.raises(TypeError):
-        Position(cartesianVelocity=[0],reference="1#this")
+        Position(cartesianVelocity=[0], reference="1#this")
+
 
 def test_no_values():
     with pytest.raises(ValueError):

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -752,44 +752,24 @@ def test_position_cartographic_degrees():
 
 def test_position_reference():
     expected_result = """{
-    "cartesian": [
-        0.0,
-        0.0,
-        0.0
-    ],
-    "reference": "this#satellite"
-}"""
-    pos = Position(cartesian=[0, 0, 0], reference="this#satellite")
-    assert str(pos) == expected_result
-    pos = Position(
-        cartesian=[0, 0, 0], reference=ReferenceValue(value="this#satellite")
-    )
-    assert str(pos) == expected_result
-
-
-def test_position_reference_only():
-    expected_result = """{
     "reference": "this#satellite"
 }"""
     pos = Position(reference="this#satellite")
     assert str(pos) == expected_result
-    pos = Position(reference=ReferenceValue(value="this#satellite"))
+    pos = Position(
+        reference=ReferenceValue(value="this#satellite")
+    )
     assert str(pos) == expected_result
 
 
 def test_viewfrom_reference():
     expected_result = """{
-    "cartesian": [
-        1.0,
-        1.0,
-        1.0
-    ],
     "reference": "this#satellite"
 }"""
-    v = ViewFrom(reference="this#satellite", cartesian=[1.0, 1.0, 1.0])
+    v = ViewFrom(reference="this#satellite")
     assert str(v) == expected_result
     v = ViewFrom(
-        reference=ReferenceValue(value="this#satellite"), cartesian=[1.0, 1.0, 1.0]
+        reference=ReferenceValue(value="this#satellite")
     )
     assert str(v) == expected_result
 
@@ -1166,13 +1146,14 @@ def test_tileset():
 
 def test_check_classes_with_references_ViewFrom():
     assert (
-        str(ViewFrom(cartesian=[0, 0, 0], reference="this#that"))
+        str(ViewFrom(reference="this#that"))
         == """{
-    "cartesian": [
-        0.0,
-        0.0,
-        0.0
-    ],
+    "reference": "this#that"
+}"""
+    )
+    assert (
+        str(ViewFrom(reference=ReferenceValue(value="this#that")))
+        == """{
     "reference": "this#that"
 }"""
     )
@@ -1214,13 +1195,8 @@ def test_check_classes_with_references_ArcType():
 
 def test_check_classes_with_references_Position():
     assert (
-        str(Position(cartesian=[0, 0, 0], reference="this#that"))
+        str(Position(reference="this#that"))
         == """{
-    "cartesian": [
-        0.0,
-        0.0,
-        0.0
-    ],
     "reference": "this#that"
 }"""
     )
@@ -1524,6 +1500,24 @@ def test_position_bad_cartesianVelocity():
     with pytest.raises(ValueError):
         Position(cartesianVelocity=[])
 
+def test_position_bad_multipleTypes():
+    with pytest.raises(TypeError):
+        Position(cartesian=[0],reference=ReferenceValue(value="1#this"))
+    with pytest.raises(TypeError):
+        Position(cartographicRadians=[0],reference=ReferenceValue(value="1#this"))
+    with pytest.raises(TypeError):
+        Position(cartographicDegrees=[0],reference=ReferenceValue(value="1#this"))
+    with pytest.raises(TypeError):
+        Position(cartesianVelocity=[0],reference=ReferenceValue(value="1#this"))
+    
+    with pytest.raises(TypeError):
+        Position(cartesian=[0],reference="1#this")
+    with pytest.raises(TypeError):
+        Position(cartographicRadians=[0],reference="1#this")
+    with pytest.raises(TypeError):
+        Position(cartographicDegrees=[0],reference="1#this")
+    with pytest.raises(TypeError):
+        Position(cartesianVelocity=[0],reference="1#this")
 
 def test_no_values():
     with pytest.raises(ValueError):

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -767,6 +767,16 @@ def test_position_reference():
     assert str(pos) == expected_result
 
 
+def test_position_reference_only():
+    expected_result = """{
+    "reference": "this#satellite"
+}"""
+    pos = Position(reference="this#satellite")
+    assert str(pos) == expected_result
+    pos = Position(reference=ReferenceValue(value="this#satellite"))
+    assert str(pos) == expected_result
+
+
 def test_viewfrom_reference():
     expected_result = """{
     "cartesian": [

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1509,7 +1509,7 @@ def test_position_bad_multipleTypes():
         Position(cartographicDegrees=[0],reference=ReferenceValue(value="1#this"))
     with pytest.raises(TypeError):
         Position(cartesianVelocity=[0],reference=ReferenceValue(value="1#this"))
-    
+
     with pytest.raises(TypeError):
         Position(cartesian=[0],reference="1#this")
     with pytest.raises(TypeError):


### PR DESCRIPTION
A position is allowed to be one of `cartesian`, `cartographicDegrees`, `cartographicRadians` or `reference` as given by the validator error statement. The validator does not check for reference only, its only checks against "cartesian*" values.