### PR TITLE
Fix: flatten polyline materials and restrict Polyline.material types

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -763,23 +763,17 @@ class Polyline(BaseCZMLObject):
     """The width of the polyline."""
     granularity: None | float | TimeIntervalCollection = Field(default=None)
     """The sampling distance, in radians."""
-    material: (
-        None
-        | PolylineMaterial
-        | str
-        | TimeIntervalCollection
-    ) = Field(default=None)
+    material: None | PolylineMaterial | str | TimeIntervalCollection = Field(
+        default=None
+    )
     """The material to use to draw the polyline. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Field>`__ for it's definition."""
     followSurface: None | bool | TimeIntervalCollection = Field(default=None)
     """Whether or not the positions are connected as great arcs (the default) or as straight lines. This property has been superseded by `arcType`, which should be used instead."""
     shadows: None | ShadowMode | TimeIntervalCollection = Field(default=None)
     """Whether or not the polyline casts or receives shadows. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/ShadowMode>`__ for it's definition."""
-    depthFailMaterial: (
-        None
-        | PolylineMaterial
-        | str
-        | TimeIntervalCollection
-    ) = Field(default=None)
+    depthFailMaterial: None | PolylineMaterial | str | TimeIntervalCollection = Field(
+        default=None
+    )
     """The material to use to draw the polyline when it is below the terrain. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Field>`__ for it's definition."""
     distanceDisplayCondition: (
         None | DistanceDisplayCondition | TimeIntervalCollection

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -141,8 +141,8 @@ class PolylineArrowMaterial(BaseCZMLObject):
     """The color of the surface. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Color>`__ for it's definition."""
 
 
-class PolylineDash(BaseCZMLObject):
-    """A definition of how a polyline should be dashed with two colors.
+class PolylineDashMaterial(BaseCZMLObject):
+    """A material that provides a how a polyline should be dashed.
 
     See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineDashMaterial>`__ for it's definition.
     """
@@ -155,16 +155,6 @@ class PolylineDash(BaseCZMLObject):
     """The length in screen-space pixels of a single dash and gap pattern. """
     dashPattern: None | int | TimeIntervalCollection = Field(default=None)
     """A 16-bit bitfield representing which portions along a single dashLength are the dash (1) and which are the gap (0). The default value, 255 (0000000011111111), indicates 50% gap followed by 50% dash."""
-
-
-class PolylineDashMaterial(BaseCZMLObject):
-    """A material that provides a how a polyline should be dashed.
-
-    See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineDashMaterial>`__ for it's definition.
-    """
-
-    polylineDash: None | PolylineDash | TimeIntervalCollection = Field(default=None)
-    """See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineDash>`__ for it's definition."""
 
 
 class PolylineMaterial(BaseCZMLObject):

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -75,14 +75,10 @@ class Material(BaseCZMLObject):
         default=None
     )
     """A material that fills the surface with a checkerboard pattern. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/CheckerboardMaterial>`__ for it's definition."""
-    polylineOutline: (
-        None | PolylineMaterial | PolylineOutline | TimeIntervalCollection
-    ) = Field(default=None)  # NOTE: Not in documentation
-    """See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineOutline>`__ for it's definition."""
 
 
-class PolylineOutline(BaseCZMLObject):
-    """A definition of how a surface is colored or shaded.
+class PolylineOutlineMaterial(BaseCZMLObject):
+    """A material that fills the surface of a line with an outlined color.
 
     See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineOutlineMaterial>`__ for it's definition.
     """
@@ -93,18 +89,6 @@ class PolylineOutline(BaseCZMLObject):
     """The color of the surface outline. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Color>`__ for it's definition."""
     outlineWidth: None | float | TimeIntervalCollection = Field(default=None)
     """The width of the outline."""
-
-
-class PolylineOutlineMaterial(BaseCZMLObject):
-    """A definition of the material wrapper for a polyline outline.
-
-    See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineOutlineMaterial>`__ for it's definition.
-    """
-
-    polylineOutline: None | PolylineOutline | TimeIntervalCollection = Field(
-        default=None
-    )
-    """See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineOutline>`__ for it's definition."""
 
 
 class PolylineGlow(BaseCZMLObject):

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -131,24 +131,14 @@ class PolylineGlowMaterial(BaseCZMLObject):
     """See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineGlow>`__ for it's definition."""
 
 
-class PolylineArrow(BaseCZMLObject):
-    """A definition of how a polyline arrow appears.
-
-    See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineArrowMaterial>`__ for it's definition.
-    """
-
-    color: None | Color | str | TimeIntervalCollection = Field(default=None)
-    """The color of the surface. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Color>`__ for it's definition."""
-
-
 class PolylineArrowMaterial(BaseCZMLObject):
     """A material that fills the surface of a line with an arrow.
 
     See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineArrowMaterial>`__ for it's definition.
     """
 
-    polylineArrow: None | PolylineArrow | TimeIntervalCollection = Field(default=None)
-    """See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineArrow>`__ for it's definition."""
+    color: None | Color | str | TimeIntervalCollection = Field(default=None)
+    """The color of the surface. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Color>`__ for it's definition."""
 
 
 class PolylineDash(BaseCZMLObject):

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -766,10 +766,6 @@ class Polyline(BaseCZMLObject):
     material: (
         None
         | PolylineMaterial
-        | PolylineDashMaterial
-        | PolylineArrowMaterial
-        | PolylineGlowMaterial
-        | PolylineOutlineMaterial
         | str
         | TimeIntervalCollection
     ) = Field(default=None)
@@ -781,10 +777,6 @@ class Polyline(BaseCZMLObject):
     depthFailMaterial: (
         None
         | PolylineMaterial
-        | PolylineDashMaterial
-        | PolylineArrowMaterial
-        | PolylineGlowMaterial
-        | PolylineOutlineMaterial
         | str
         | TimeIntervalCollection
     ) = Field(default=None)

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -91,8 +91,8 @@ class PolylineOutlineMaterial(BaseCZMLObject):
     """The width of the outline."""
 
 
-class PolylineGlow(BaseCZMLObject):
-    """A definition of how a glowing polyline appears.
+class PolylineGlowMaterial(BaseCZMLObject):
+    """A material that fills the surface of a line with a glowing color.
 
     See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineGlowMaterial>`__ for it's definition.
     """
@@ -103,16 +103,6 @@ class PolylineGlow(BaseCZMLObject):
     """The strength of the glow."""
     taperPower: None | float | TimeIntervalCollection = Field(default=None)
     """The strength of the tapering effect. 1.0 and higher means no tapering."""
-
-
-class PolylineGlowMaterial(BaseCZMLObject):
-    """A material that fills the surface of a line with a glowing color.
-
-    See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineGlowMaterial>`__ for it's definition.
-    """
-
-    polylineGlow: None | PolylineGlow | TimeIntervalCollection = Field(default=None)
-    """See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PolylineGlow>`__ for it's definition."""
 
 
 class PolylineArrowMaterial(BaseCZMLObject):

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -29,7 +29,6 @@ from czml3.properties import (
     PolylineGlow,
     PolylineGlowMaterial,
     PolylineMaterial,
-    PolylineOutline,
     PolylineOutlineMaterial,
     Position,
     PositionList,
@@ -404,8 +403,8 @@ def test_packet_polyline_outline():
             positions=PositionList(
                 cartographicDegrees=[-75, 43, 500000, -125, 43, 500000]
             ),
-            material=PolylineOutlineMaterial(
-                polylineOutline=PolylineOutline(
+            material=PolylineMaterial(
+                polylineOutline=PolylineOutlineMaterial(
                     color=Color(rgba=[255, 0, 0, 255]),
                     outlineColor=Color(rgba=[255, 0, 0, 255]),
                     outlineWidth=2,

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -24,7 +24,6 @@ from czml3.properties import (
     Point,
     Polygon,
     Polyline,
-    PolylineArrow,
     PolylineArrowMaterial,
     PolylineDash,
     PolylineDashMaterial,
@@ -503,8 +502,8 @@ def test_packet_polyline_arrow():
             positions=PositionList(
                 cartographicDegrees=[-75, 43, 500000, -125, 43, 500000]
             ),
-            material=PolylineArrowMaterial(
-                polylineArrow=PolylineArrow(color=Color(rgba=[255, 0, 0, 255]))
+            material=PolylineMaterial(
+                polylineArrow=PolylineArrowMaterial(color=Color(rgba=[255, 0, 0, 255]))
             ),
         ),
     )

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -26,7 +26,6 @@ from czml3.properties import (
     Polyline,
     PolylineArrowMaterial,
     PolylineDashMaterial,
-    PolylineGlow,
     PolylineGlowMaterial,
     PolylineMaterial,
     PolylineOutlineMaterial,
@@ -453,8 +452,8 @@ def test_packet_polyline_glow():
             positions=PositionList(
                 cartographicDegrees=[-75, 43, 500000, -125, 43, 500000]
             ),
-            material=PolylineGlowMaterial(
-                polylineGlow=PolylineGlow(
+            material=PolylineMaterial(
+                polylineGlow=PolylineGlowMaterial(
                     color=Color(rgba=[255, 0, 0, 255]),
                     glowPower=0.2,
                     taperPower=0.5,

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -25,7 +25,6 @@ from czml3.properties import (
     Polygon,
     Polyline,
     PolylineArrowMaterial,
-    PolylineDash,
     PolylineDashMaterial,
     PolylineGlow,
     PolylineGlowMaterial,
@@ -545,8 +544,8 @@ def test_packet_polyline_dashed():
             positions=PositionList(
                 cartographicDegrees=[-75, 43, 500000, -125, 43, 500000]
             ),
-            material=PolylineDashMaterial(
-                polylineDash=PolylineDash(color=Color(rgba=[255, 0, 0, 255]))
+            material=PolylineMaterial(
+                polylineDash=PolylineDashMaterial(color=Color(rgba=[255, 0, 0, 255]))
             ),
         ),
     )

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -38,7 +38,6 @@ from czml3.properties import (
     Polygon,
     Polyline,
     PolylineArrowMaterial,
-    PolylineDash,
     PolylineDashMaterial,
     PolylineGlow,
     PolylineGlowMaterial,
@@ -295,8 +294,8 @@ def test_dashmaterial_colors():
         "dashPattern": 255
     }
 }"""
-    dashmat = PolylineDashMaterial(
-        polylineDash=PolylineDash(
+    dashmat = PolylineMaterial(
+        polylineDash=PolylineDashMaterial(
             color=Color(rgba=[200, 100, 30, 255]),
             gapColor=Color(rgba=[100, 200, 0, 255]),
             dashLength=16,

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -37,7 +37,6 @@ from czml3.properties import (
     Point,
     Polygon,
     Polyline,
-    PolylineArrow,
     PolylineArrowMaterial,
     PolylineDash,
     PolylineDashMaterial,
@@ -266,8 +265,8 @@ def test_arrowmaterial_color():
         }
     }
 }"""
-    pamat = PolylineArrowMaterial(
-        polylineArrow=PolylineArrow(color=Color(rgba=[200, 100, 30, 255])),
+    pamat = PolylineMaterial(
+        polylineArrow=PolylineArrowMaterial(color=Color(rgba=[200, 100, 30, 255])),
     )
 
     assert str(pamat) == expected_result

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -42,7 +42,6 @@ from czml3.properties import (
     PolylineGlow,
     PolylineGlowMaterial,
     PolylineMaterial,
-    PolylineOutline,
     PolylineOutlineMaterial,
     Position,
     PositionList,
@@ -351,8 +350,8 @@ def test_outline_material_colors():
         "outlineWidth": 3.0
     }
 }"""
-    omat = PolylineOutlineMaterial(
-        polylineOutline=PolylineOutline(
+    omat = PolylineMaterial(
+        polylineOutline=PolylineOutlineMaterial(
             color=Color(rgba=[200, 100, 30, 255]),
             outlineColor=Color(rgba=[100, 200, 0, 255]),
             outlineWidth=3,

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -39,7 +39,6 @@ from czml3.properties import (
     Polyline,
     PolylineArrowMaterial,
     PolylineDashMaterial,
-    PolylineGlow,
     PolylineGlowMaterial,
     PolylineMaterial,
     PolylineOutlineMaterial,
@@ -320,8 +319,8 @@ def test_glowmaterial_color():
         "taperPower": 0.3
     }
 }"""
-    glowmat = PolylineGlowMaterial(
-        polylineGlow=PolylineGlow(
+    glowmat = PolylineMaterial(
+        polylineGlow=PolylineGlowMaterial(
             color=Color(rgba=[200, 100, 30, 255]), glowPower=0.7, taperPower=0.3
         )
     )


### PR DESCRIPTION
- Flattened PolylineArrowMaterial, PolylineDashMaterial, PolylineOutlineMaterial, and PolylineGlowMaterial
- Removed redundant nesting of material properties
- Restricted Polyline.material and Polyline.depthFailMaterial to accept only PolylineMaterial, str, or TimeIntervalCollection
- Updated tests accordingly