### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/czml3/base.py
+++ b/src/czml3/base.py
@@ -16,7 +16,7 @@ class BaseCZMLObject(BaseModel):
     @model_validator(mode="after")
     def check_delete(self) -> Self:
         if hasattr(self, "delete") and self.delete:
-            for k in self.model_fields:
+            for k in type(self).model_fields:
                 if k not in NON_DELETE_PROPERTIES and getattr(self, k) is not None:
                     setattr(self, k, None)
         return self


### PR DESCRIPTION
As per Pydantic documentation, model_fields is a class attribute and access from an instance will be deprecated in v3.0:
https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_fields

This PR aims to solve this issue by accessing the attribute by resolving dynamically the class of the instance.

An alternative approach, would be to use the attribute model_fields_set:
https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_fields_set