### PR TITLE
Extend type mapping for IntervalValue

### DIFF
--- a/src/czml3/types.py
+++ b/src/czml3/types.py
@@ -20,7 +20,14 @@ if sys.version_info[1] >= 11:
 else:
     from typing_extensions import Self  # pragma: no cover
 
-TYPE_MAPPING = {bool: "boolean"}
+TYPE_MAPPING = {
+    bool: "boolean",
+    float: "number",
+    int: "number",
+    list: "number",
+    set: "number",
+    tuple: "number",
+}
 
 
 def get_color(color: None | list[float], max_val: float) -> list[float] | None:

--- a/src/czml3/types.py
+++ b/src/czml3/types.py
@@ -26,6 +26,7 @@ TYPE_MAPPING = {
     int: "number",
     list: "number",
     set: "number",
+    str: "string",
     tuple: "number",
 }
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -189,6 +189,15 @@ def test_interval_value():
 }"""
     )
 
+    # value is a string
+    assert (
+        str(IntervalValue(start=start, end=end, value="Text"))
+        == """{
+    "interval": "2019-01-01T12:00:00.000000Z/2019-09-02T21:59:59.000000Z",
+    "string": "Text"
+}"""
+    )
+
     # value is a float
     assert (
         str(IntervalValue(start=start, end=end, value=1.1))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -189,6 +189,60 @@ def test_interval_value():
 }"""
     )
 
+    # value is a float
+    assert (
+        str(IntervalValue(start=start, end=end, value=1.1))
+        == """{
+    "interval": "2019-01-01T12:00:00.000000Z/2019-09-02T21:59:59.000000Z",
+    "number": 1.1
+}"""
+    )
+
+    # value is an integer
+    assert (
+        str(IntervalValue(start=start, end=end, value=1))
+        == """{
+    "interval": "2019-01-01T12:00:00.000000Z/2019-09-02T21:59:59.000000Z",
+    "number": 1
+}"""
+    )
+
+    # value is a list of floats
+    assert (
+        str(IntervalValue(start=start, end=end, value=[1.1, 2.2]))
+        == """{
+    "interval": "2019-01-01T12:00:00.000000Z/2019-09-02T21:59:59.000000Z",
+    "number": [
+        1.1,
+        2.2
+    ]
+}"""
+    )
+
+    # value is a set of ints
+    assert (
+        str(IntervalValue(start=start, end=end, value={1, 2}))
+        == """{
+    "interval": "2019-01-01T12:00:00.000000Z/2019-09-02T21:59:59.000000Z",
+    "number": [
+        1,
+        2
+    ]
+}"""
+    )
+
+    # value is a tuple of floats or ints
+    assert (
+        str(IntervalValue(start=start, end=end, value=(1.1, 2)))
+        == """{
+    "interval": "2019-01-01T12:00:00.000000Z/2019-09-02T21:59:59.000000Z",
+    "number": [
+        1.1,
+        2
+    ]
+}"""
+    )
+
     assert (
         str(
             IntervalValue(


### PR DESCRIPTION
This PR aims to extend the type mapping used by IntervalValue, so to be able to use it for other types other than booleans.