### PR TITLE
Fix serialization of reference values for Uri properties

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -1955,11 +1955,11 @@ class Uri(BaseCZMLObject, Deletable):
     @model_serializer
     def custom_serializer(
         self,
-    ) -> str | dict[str, bool | str | ReferenceValue] | TimeIntervalCollection | None:
+    ) -> str | dict[str, bool | ReferenceValue] | TimeIntervalCollection | None:
         if self.delete:
             return {"delete": True}
         if self.uri is not None:
             return self.uri
-        if self.reference is None or isinstance(self.reference, TimeIntervalCollection):
-            return self.reference
-        return {"reference": self.reference}
+        if isinstance(self.reference, ReferenceValue):
+            return {"reference": self.reference}
+        return self.reference

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -1797,7 +1797,11 @@ class Uri(BaseCZMLObject, Deletable):
     @model_serializer
     def custom_serializer(
         self,
-    ) -> None | str | dict[str, bool] | TimeIntervalCollection:
+    ) -> str | dict[str, bool | str | ReferenceValue] | TimeIntervalCollection | None:
         if self.delete:
             return {"delete": True}
-        return self.uri if self.uri is not None else str(self.reference)
+        if self.uri is not None:
+            return self.uri
+        if self.reference is None or isinstance(self.reference, TimeIntervalCollection):
+            return self.reference
+        return {"reference": self.reference}

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1675,6 +1675,9 @@ def test_position_list_of_lists_with_cartographicRadians():
     )
     assert str(p1) == expected_result
 
+    p2 = PositionListOfLists(cartographicRadians=[[1, 2, 3]])
+    assert str(p2) == expected_result
+
 
 def test_position_list_of_lists_with_cartographicDegrees():
     expected_result = """{
@@ -2210,12 +2213,40 @@ def test_Orientation_delete():
     assert str(p) == expected_result
 
 
-def test_Uri_delete():
+def test_uri_delete():
     expected_result = """{
     "delete": true
 }"""
     p = Uri(delete=True, reference="this#that")
     assert p.delete
+    assert str(p) == expected_result
+
+
+def test_uri_multiple_interval_value():
+    expected_result = """[
+    {
+        "interval": "2019-01-01T00:00:00.000000Z/2019-01-02T00:00:00.000000Z",
+        "string": "this#that"
+    },
+    {
+        "interval": "2019-01-02T00:00:00.000000Z/2019-01-03T00:00:00.000000Z",
+        "string": "that#this"
+    }
+]"""
+
+    start0 = dt.datetime(2019, 1, 1, tzinfo=dt.timezone.utc)
+    end0 = start1 = dt.datetime(2019, 1, 2, tzinfo=dt.timezone.utc)
+    end1 = dt.datetime(2019, 1, 3, tzinfo=dt.timezone.utc)
+
+    time_interval_collection = TimeIntervalCollection(
+        values=[
+            IntervalValue(start=start0, end=end0, value="this#that"),
+            IntervalValue(start=start1, end=end1, value="that#this"),
+        ]
+    )
+
+    p = Uri(reference=time_interval_collection)
+
     assert str(p) == expected_result
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -422,6 +422,7 @@ def test_check_reference():
     with pytest.raises(TypeError):
         check_reference("thisthat")
     assert check_reference("this#that") is None
+    assert check_reference(None) is None
 
 
 def test_format_datetime_like():


### PR DESCRIPTION
This PR aims at fixing the serialization of Uri properties, when their reference value has been set to either a string or a ReferenceValue instance.