### PR TITLE
Allow ArcType to be set directly to an enum value

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -930,9 +930,9 @@ class ArcType(BaseCZMLObject, Deletable):
     @field_validator("arcType")
     @classmethod
     def validate_arc_type(cls, t):
-        if isinstance(t, str):
-            return ArcTypes(t)
-        return t
+        if t is None or isinstance(t, ArcTypes):
+            return t
+        return ArcTypes(t)
 
     @field_validator("reference")
     @classmethod

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -927,6 +927,13 @@ class ArcType(BaseCZMLObject, Deletable):
             raise TypeError("Only one of arcType or reference must be given")
         return self
 
+    @field_validator("arcType")
+    @classmethod
+    def validate_arc_type(cls, t):
+        if isinstance(t, str):
+            return ArcTypes(t)
+        return t
+
     @field_validator("reference")
     @classmethod
     def validate_reference(cls, r):

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -702,7 +702,7 @@ class Polygon(BaseCZMLObject):
     """The array of positions defining a simple polygon. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PositionList>`__ for it's definition."""
     show: None | bool | TimeIntervalCollection = Field(default=None)
     """Whether or not the polygon is shown."""
-    arcType: None | ArcType | TimeIntervalCollection = Field(default=None)
+    arcType: None | ArcTypes | ArcType | TimeIntervalCollection = Field(default=None)
     """The type of arc that should connect the positions of the polygon. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/ArcType>`__ for it's definition."""
     granularity: None | float | TimeIntervalCollection = Field(default=None)
     """The sampling distance, in radians."""
@@ -760,7 +760,7 @@ class Polyline(BaseCZMLObject):
     """Whether or not the polyline is shown."""
     positions: PositionList | TimeIntervalCollection = Field()
     """The array of positions defining the polyline as a line strip."""
-    arcType: None | ArcType | TimeIntervalCollection = Field(default=None)
+    arcType: None | ArcTypes | ArcType | TimeIntervalCollection = Field(default=None)
     """The type of arc that should connect the positions of the polyline. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/ArcType>`__ for it's definition."""
     width: None | float | TimeIntervalCollection = Field(default=None)
     """The width of the polyline."""

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -200,9 +200,7 @@ def test_polyline():
             10.0
         ]
     },
-    "arcType": {
-        "arcType": "GEODESIC"
-    },
+    "arcType": "GEODESIC",
     "distanceDisplayCondition": {
         "distanceDisplayCondition": [
             14.0,
@@ -217,7 +215,7 @@ def test_polyline():
         positions=PositionList(
             cartographicDegrees=CartographicDegreesListValue(values=[20, 30, 10])
         ),
-        arcType=ArcType(arcType="GEODESIC"),
+        arcType=ArcTypes.GEODESIC,
         distanceDisplayCondition=DistanceDisplayCondition(
             distanceDisplayCondition=DistanceDisplayConditionValue(values=[14, 81])
         ),

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -184,6 +184,19 @@ def test_arc_type():
     assert str(arc_type) == expected_result
 
 
+def test_arc_type_from_string():
+    expected_result = """{
+    "arcType": "RHUMB"
+}"""
+    arc_type = ArcType(arcType="RHUMB")
+    assert str(arc_type) == expected_result
+
+
+def test_bad_arc_type_from_string():
+    with pytest.raises(ValueError):
+        ArcType(arcType="INVALID_ARC_TYPE")
+
+
 def test_shadow_mode():
     expected_result = """{
     "shadowMode": "ENABLED"
@@ -193,6 +206,43 @@ def test_shadow_mode():
 
 
 def test_polyline():
+    expected_result = """{
+    "positions": {
+        "cartographicDegrees": [
+            20.0,
+            30.0,
+            10.0
+        ]
+    },
+    "arcType": {
+        "arcType": "GEODESIC"
+    },
+    "distanceDisplayCondition": {
+        "distanceDisplayCondition": [
+            14.0,
+            81.0
+        ]
+    },
+    "classificationType": {
+        "classificationType": "CESIUM_3D_TILE"
+    }
+}"""
+    pol = Polyline(
+        positions=PositionList(
+            cartographicDegrees=CartographicDegreesListValue(values=[20, 30, 10])
+        ),
+        arcType=ArcType(arcType="GEODESIC"),
+        distanceDisplayCondition=DistanceDisplayCondition(
+            distanceDisplayCondition=DistanceDisplayConditionValue(values=[14, 81])
+        ),
+        classificationType=ClassificationType(
+            classificationType=ClassificationTypes.CESIUM_3D_TILE
+        ),
+    )
+    assert str(pol) == expected_result
+
+
+def test_polyline_with_enum_arc_type():
     expected_result = """{
     "positions": {
         "cartographicDegrees": [


### PR DESCRIPTION
This PR aims at allowing to set and serialize ArcType values directly to a value in the ArcTypes enum, as supported by Cesium:
https://sandcastle.cesium.com/?id=czml-polyline (lineno: 81)