### PR TITLE
Added LineOffset class + LineOffset tests

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -282,7 +282,9 @@ class GridMaterial(BaseCZMLObject):
     """The number of grid lines along each axis. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/LineCount>`__ for it's definition."""
     lineThickness: None | list[float] | TimeIntervalCollection = Field(default=None)
     """The thickness of grid lines along each axis, in pixels. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/LineThickness>`__ for it's definition."""
-    lineOffset: None | list[float] | TimeIntervalCollection = Field(default=None)
+    lineOffset: None | list[float] | LineOffset | TimeIntervalCollection = Field(
+        default=None
+    )
     """The offset of grid lines along each axis, as a percentage from 0 to 1. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/LineOffset>`__ for it's definition."""
 
 
@@ -1756,6 +1758,41 @@ class Rotation(BaseCZMLObject, Interpolatable, Deletable):
         if isinstance(q, list):
             return UnitQuaternionValue(values=q)
         return q
+
+    @field_validator("reference")
+    @classmethod
+    def validate_reference(cls, r):
+        if isinstance(r, str):
+            return ReferenceValue(value=r)
+        return r
+
+
+class LineOffset(BaseCZMLObject, Interpolatable, Deletable):
+    """The offset of grid lines along each axis, as a percentage from 0 to 1.
+    See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/LineOffset>`__ for its definition.
+    """
+
+    cartesian2: None | list[float] | Cartesian2Value = Field(default=None)
+    """The offset specified as a 2D Cartesian value. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Cartesian2Value>`__ for its definition."""
+    reference: None | ReferenceValue | str | TimeIntervalCollection = Field(
+        default=None
+    )
+    """The value specified as a reference to another property. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/ReferenceValue>`__ for it's definition."""
+
+    @model_validator(mode="after")
+    def checks(self):
+        if self.delete:
+            return self
+        if sum(val is not None for val in (self.cartesian2, self.reference)) != 1:
+            raise TypeError("Only one of cartesian2 or reference must be given")
+        return self
+
+    @field_validator("cartesian2")
+    @classmethod
+    def validate_cartesian2(cls, c):
+        if isinstance(c, list):
+            return Cartesian2Value(values=c)
+        return c
 
     @field_validator("reference")
     @classmethod

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -31,6 +31,7 @@ from czml3.properties import (
     HeightReference,
     ImageMaterial,
     Label,
+    LineOffset,
     Material,
     Model,
     NearFarScalar,
@@ -715,6 +716,22 @@ def test_rotation_has_one_property():
         Rotation(reference="this#that", unitQuaternion=[0, 0, 0, 0])
 
 
+def test_line_offset_has_delete():
+    expected_result = """{
+    "delete": true
+}"""
+    lo = LineOffset(delete=True, reference="this#that")
+    assert lo.delete
+    assert str(lo) == expected_result
+
+
+def test_line_offset_has_one_property():
+    with pytest.raises(
+        TypeError, match="Only one of cartesian2 or reference must be given"
+    ):
+        LineOffset(reference="this#that", cartesian2=[0, 0])
+
+
 def test_position_list_has_delete():
     expected_result = """{
     "delete": true
@@ -1003,6 +1020,46 @@ def test_rotation_with_reference():
 }"""
 
     result = Rotation(reference=ReferenceValue(value="this#that"))
+
+    assert str(result) == expected_result
+
+
+def test_line_offset_cartesian2():
+    expected_result = """{
+    "cartesian2": {
+        "cartesian2": [
+            0.0,
+            1.0
+        ]
+    }
+}"""
+
+    result = LineOffset(cartesian2=Cartesian2Value(values=[0.0, 1.0]))
+
+    assert str(result) == expected_result
+
+
+def test_line_offset_cartesian2_as_list():
+    expected_result = """{
+    "cartesian2": {
+        "cartesian2": [
+            0.0,
+            1.0
+        ]
+    }
+}"""
+
+    result = LineOffset(cartesian2=[0.0, 1.0])
+
+    assert str(result) == expected_result
+
+
+def test_line_offset_with_reference():
+    expected_result = """{
+    "reference": "this#that"
+}"""
+
+    result = LineOffset(reference=ReferenceValue(value="this#that"))
 
     assert str(result) == expected_result
 


### PR DESCRIPTION
- Created the LineOffset class in properties.py to support 2D Cartesian offsets.

- Updated GridMaterial to include the lineOffset property.

- Added unit tests in properties_test.py to verify that LineOffset correctly handles both direct cartesian2 values and reference strings.