### PR TITLE
Fix NumberValue serialization when parent model serialize_by_alias is enabled

### DIFF
--- a/src/czml3/types.py
+++ b/src/czml3/types.py
@@ -625,6 +625,6 @@ class NumberValue(BaseCZMLObject, Interpolatable, Deletable):
     """A single number, or a list of number pairs signifying the time and representative value."""
 
     number: int | float | list[int] | list[float] | list[int | float] = Field(
-        alias="values"
+        alias="values", serialization_alias="number"
     )
     """The numerical value or values."""


### PR DESCRIPTION
This PR aims to solve a small issue when serializing models with NumberValue, where the serialization by alias is enabled.
The current implementation, uses the `values` alias to set the content for backwards compatibility, but serialization shall ensure `number` is used as object key.