### PR TITLE
Remove undocumented properties

### DIFF
--- a/src/czml3/__init__.py
+++ b/src/czml3/__init__.py
@@ -1,5 +1,5 @@
 from .core import CZML_VERSION, Document, Packet
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 
 __all__ = ["Document", "Packet", "CZML_VERSION"]

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -419,12 +419,6 @@ class Position(BaseCZMLObject, Interpolatable, Deletable):
         default=None
     )
     """The position specified as a reference to another property. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/ReferenceValue>`__ for it's definition."""
-    interval: None | TimeInterval | TimeIntervalCollection = Field(
-        default=None
-    )  # NOTE: not found in documentation
-    epoch: None | str | dt.datetime | TimeIntervalCollection = Field(
-        default=None
-    )  # NOTE: not found in documentation
 
     @model_validator(mode="after")
     def checks(self):
@@ -482,11 +476,6 @@ class Position(BaseCZMLObject, Interpolatable, Deletable):
         if isinstance(r, list):
             return Cartesian3VelocityValue(values=r)
         return r
-
-    @field_validator("epoch")
-    @classmethod
-    def validate_epoch(cls, e):
-        return format_datetime_like(e)
 
 
 class ViewFrom(BaseCZMLObject, Interpolatable, Deletable):
@@ -1162,9 +1151,6 @@ class PositionList(BaseCZMLObject, Deletable):
     interval: None | TimeInterval | TimeIntervalCollection = Field(
         default=None
     )  # NOTE: not in documentation
-    epoch: None | str | dt.datetime | TimeIntervalCollection = Field(
-        default=None
-    )  # NOTE: not in documentation
 
     @model_validator(mode="after")
     def checks(self):
@@ -1216,11 +1202,6 @@ class PositionList(BaseCZMLObject, Deletable):
         if isinstance(r, list):
             return CartographicDegreesListValue(values=r)
         return r
-
-    @field_validator("epoch")
-    @classmethod
-    def check(cls, e):
-        return format_datetime_like(e)
 
 
 class Ellipsoid(BaseCZMLObject):
@@ -1738,9 +1719,6 @@ class Rotation(BaseCZMLObject, Interpolatable, Deletable):
         default=None
     )
     """The value specified as a reference to another property. See `here <https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/ReferenceValue>`__ for it's definition."""
-    epoch: None | str | dt.datetime | TimeIntervalCollection = Field(
-        default=None
-    )  # NOTE: not found in documentation
 
     @model_validator(mode="after")
     def checks(self):

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -411,22 +411,6 @@ def test_outline_material_colors():
     assert str(omat) == expected_result
 
 
-def test_positionlist_epoch():
-    expected_result = """{
-    "cartographicDegrees": [
-        200.0,
-        100.0,
-        30.0
-    ],
-    "epoch": "2019-06-11T12:26:58.000000Z"
-}"""
-    p = PositionList(
-        epoch=dt.datetime(2019, 6, 11, 12, 26, 58, tzinfo=dt.timezone.utc),
-        cartographicDegrees=[200, 100, 30],
-    )
-    assert str(p) == expected_result
-
-
 def test_colors_rgba():
     Color(rgba=[255, 204, 0, 55])
     Color(rgba=[255, 204, 55])
@@ -813,16 +797,6 @@ def test_position_has_given_epoch():
     )
 
     pos = Position(epoch=expected_epoch, cartesian=[0, 0, 0])
-
-    assert pos.epoch == expected_epoch
-
-
-def test_positionlist_has_given_epoch():
-    expected_epoch = format_datetime_like(
-        dt.datetime(2019, 6, 11, 12, 26, 58, tzinfo=dt.timezone.utc)
-    )
-
-    pos = PositionList(epoch=expected_epoch, cartesian=[0, 0, 0])
 
     assert pos.epoch == expected_epoch
 


### PR DESCRIPTION
- Remove `Position.interval`
- Remove `Position.epoch`
- Remove `PositionList.epoch`
- Remove `Ellipsoid.epoch`
- Remove associated tests
- Bump to v3.3.1

The properties were removed as they do not appear in the [CZML Writer](https://github.com/AnalyticalGraphicsInc/czml-writer).